### PR TITLE
feat: add settings var for file count and file size

### DIFF
--- a/global.go
+++ b/global.go
@@ -539,3 +539,9 @@ var handlersRegistered = false
 var defaultProgressBarColor = "#07c"
 
 var settingsSynched = false
+
+// MaxFileSizeInUserForm is the maximum file size in bytes for a file upload in user form
+var MaxFileSizeInUserInput = int64(5 * 1024 * 1024)
+
+// MaxFilesCountInUserForm is the maximum number of files that user can upload in single form input
+var MaxFilesCountPerUserInput = 5

--- a/setting.go
+++ b/setting.go
@@ -303,6 +303,10 @@ func (s *Setting) ApplyValue() {
 		CSRFCacheDefaultExpiration = v.(int)
 	case "uAdmin.CSRFCacheCleanupInterval":
 		CSRFCacheCleanupInterval = v.(int)
+	case "uAdmin.MaxUploadFileSizeInUserInputForm":
+		MaxFileSizeInUserInput = int64(v.(int))
+	case "uAdmin.MaxFileCountInUserInputForm":
+		MaxFilesCountPerUserInput = v.(int)
 	}
 }
 
@@ -904,6 +908,20 @@ func syncSystemSettings() {
 			DefaultValue: "24",
 			DataType:     t.Integer(),
 			Help:         "is the number of hours to clear expired cache",
+		},
+		{
+			Name:         "Max Upload File Size In User Input Form",
+			Value:        fmt.Sprint(MaxFileSizeInUserInput),
+			DefaultValue: "52428800",
+			DataType:     t.Integer(),
+			Help:         "is the maximum upload file size in bytes. 1MB = 1024 * 1024; for example in labor_dispute/prevent_corruption/public_information_request/appeal",
+		},
+		{
+			Name:         "Max File Count In User Input Form",
+			Value:        fmt.Sprint(MaxFilesCountPerUserInput),
+			DefaultValue: "5",
+			DataType:     t.Integer(),
+			Help:         "is the maximum files count in single form input; for example in labor_dispute/prevent_corruption/public_information_request/appeal",
 		},
 	}
 


### PR DESCRIPTION
This PR introduces two new setting variables:

`MaxFileSizeInUserInput` - maximum file size of the single file that a user can upload in  the form
`MaxFilesCountPerUserInput` - maximum amount of files that user can upload in input in the form, one form can has more that one input field.

will be used for forms:
- labor_dispute
- prevent_corruption
- public_information_request
- appeal

