### PR TITLE
feat: add base path for share feature

### DIFF
--- a/global.go
+++ b/global.go
@@ -545,3 +545,7 @@ var MaxFileSizeInUserInput = int64(5 * 1024 * 1024)
 
 // MaxFilesCountInUserForm is the maximum number of files that user can upload in single form input
 var MaxFilesCountPerUserInput = 5
+
+// OriginSitePath is the original site path where the application is hosted
+// is used to generate full URLs for FB crawler and other similar services
+var OriginSitePath = ""

--- a/setting.go
+++ b/setting.go
@@ -307,6 +307,8 @@ func (s *Setting) ApplyValue() {
 		MaxFileSizeInUserInput = int64(v.(int))
 	case "uAdmin.MaxFileCountInUserInputForm":
 		MaxFilesCountPerUserInput = v.(int)
+	case "uAdmin.OriginSitePath":
+		OriginSitePath = strings.TrimSpace(v.(string))
 	}
 }
 
@@ -922,6 +924,13 @@ func syncSystemSettings() {
 			DefaultValue: "5",
 			DataType:     t.Integer(),
 			Help:         "is the maximum files count in single form input; for example in labor_dispute/prevent_corruption/public_information_request/appeal",
+		},
+		{
+			Name:         "Origin Site Path",
+			Value:        OriginSitePath,
+			DefaultValue: "",
+			DataType:     t.String(),
+			Help:         "is the original site path where the application is hosted. Is used to generate correct URLs for Meta (X) crawlers (share functionality)",
 		},
 	}
 


### PR DESCRIPTION
This PR introduces a new variable `OriginSitePath` in the uadmin settings
This variable will be used for creating a path in `seo` respounce.

The backend needs to know the host address of the UI.